### PR TITLE
More caution when accessing event handler dictionary

### DIFF
--- a/GameEventsBroadcaster.cs
+++ b/GameEventsBroadcaster.cs
@@ -86,7 +86,8 @@ namespace Net.Xeophin.Utils
       OnGameStateChanged (sender, e);
 
       // Call more specific events
-      var handler = gameStateEvents [e.NewState];
+      EventHandler<GameStateEventArgs> handler;
+      gameStateEvents.TryGetValue(e.NewState, handler);
       if (handler != null)
         handler (sender, e);
 


### PR DESCRIPTION
Re: #1: Instead of directly trying to get the handlers for an event, it will now check whether there are values at all.
